### PR TITLE
Store organic queries and reduce Synthetic queries for miners

### DIFF
--- a/neurons/validators/advanced_scraper_validator.py
+++ b/neurons/validators/advanced_scraper_validator.py
@@ -2,7 +2,7 @@ import torch
 import random
 import asyncio
 import time
-from typing import List, Optional
+from typing import List, Optional, Any, Dict
 import bittensor as bt
 from datura.stream import collect_final_synapses
 from reward import RewardModelType, RewardScoringType
@@ -32,7 +32,7 @@ from neurons.validators.utils.tasks import TwitterTask
 from neurons.validators.organic_query_state import OrganicQueryState
 from neurons.validators.penalty.streaming_penalty import StreamingPenaltyModel
 from neurons.validators.penalty.exponential_penalty import ExponentialTimePenaltyModel
-
+from collections import defaultdict
 
 class AdvancedScraperValidator:
     def __init__(self, neuron: AbstractNeuron):
@@ -87,6 +87,7 @@ class AdvancedScraperValidator:
 
         self.synthetic_history = []
         self.organic_query_state = OrganicQueryState()
+        self.organic_history: Dict[Any, Dict[str, Any]] = defaultdict(dict)  # {uid: {'synapse': synapse,'timestep': time.time()}}
         # Init device.
         bt.logging.debug("loading", "device")
         bt.logging.debug(
@@ -453,15 +454,38 @@ class AdvancedScraperValidator:
                 bt.logging.info("No available UIDs, skipping task execution.")
                 return
 
-            dataset = QuestionsDataset()
+            THRESHOLD = time.time() - 3600 * 4 #4 hours of threshold to remove entries
+            # Cleanup the organic history to remove entries older than 4 hours
+            self.organic_history = {uid: data for uid, data in self.organic_history.items() if data['timestamp'] >= THRESHOLD}
+            
+            # Parameters for synthetic query
+            random_model = self.get_random_execution_time()
             tools = random.choice(self.tools)
+            date_filter = get_random_date_filter()
+            synthetic_date_filter_dtype = date_filter.date_filter_type
 
-            prompts = await asyncio.gather(
-                *[
-                    dataset.generate_new_question_with_openai(tools)
-                    for _ in range(len(self.neuron.available_uids))
-                ]
-            )
+            # Filtering UIDs from organic history that match the model, tools and date_filter
+            selected_queries_from_history = {
+                uid:data for uid, data in self.organic_history.items() if (
+                data['synapse'].model == random_model and 
+                data['synapse'].tools == tools and 
+                data['synapse'].date_filter_type == synthetic_date_filter_dtype
+            )}
+            # Exclude the Organic UIDs from the available UIDs
+            unused_uids = self.neuron.available_uids - selected_queries_from_history.keys()       
+
+            if self.organic_history: #If there are no organic history entries, Fallback to the synthetic query method
+                prompts = [data['synapse'].prompt for _, data in selected_queries_from_history.items()]
+            else:
+                bt.logging.info("No organic history, falling back to synthetic search.")
+                dataset = QuestionsDataset()
+
+                prompts = await asyncio.gather(
+                    *[
+                        dataset.generate_new_question_with_openai(tools)
+                        for _ in range(len(unused_uids))
+                    ]
+                )
 
             tasks = [
                 TwitterTask(
@@ -477,14 +501,14 @@ class AdvancedScraperValidator:
                 f"Query and score running with prompts: {prompts} and tools: {tools}"
             )
 
-            random_model = self.get_random_execution_time()
             max_execution_time = get_max_execution_time(random_model)
 
             async_responses, uids, event, start_time = await self.run_task_and_score(
                 tasks=tasks,
                 strategy=strategy,
                 is_only_allowed_miner=False,
-                date_filter=get_random_date_filter(),
+                specified_uids=unused_uids,
+                date_filter=date_filter,
                 tools=tools,
                 language=self.language,
                 region=self.region,
@@ -496,13 +520,25 @@ class AdvancedScraperValidator:
                 async_responses, uids, start_time, max_execution_time
             )
 
+            # Collect organic responses for matching UIDs
+            # Merge if the response exists because we are making the responses None for Organic UIDs that were processed in previous synthetic
+            merged_responses = [data['synapse'] for data in selected_queries_from_history.values() if data['synapse']]
+            merged_uids = [uid for uid, data in selected_queries_from_history.items() if data['synapse']]
+            merged_responses.extend(final_synapses)
+            merged_uids.extend(uids.tolist())
+            # Update responses and uids with merged data
+            final_synapses = merged_responses
+            uids = torch.Tensor(merged_uids, device = self.neuron.config.neuron.device)
             # Store final synapses for scoring later
             self.synthetic_history.append(
                 (event, tasks, final_synapses, uids, start_time)
             )
 
             await self.score_random_synthetic_query()
-
+            # Remove used organic responses from history
+            for uid in uids:
+                if (entry := self.organic_history.get(uid)):  
+                    entry['synapse'] = None
         except Exception as e:
             bt.logging.error(f"Error in query_and_score: {e}")
             raise e
@@ -627,6 +663,13 @@ class AdvancedScraperValidator:
                     self.organic_query_state.save_organic_queries(
                         final_synapses, uids, original_rewards
                     )
+                # Save organic queries in `self.organic_history` if not an interval query
+                if not is_interval_query:
+                    for uid_tensor, synapse in zip(uids, final_synapses):
+                        self.organic_history[uid_tensor.item()] = {
+                            'synapse': synapse,
+                            'timestamp': start_time
+                        }
 
             asyncio.create_task(process_and_score_responses(uids))
         except Exception as e:


### PR DESCRIPTION
This pull request introduces significant enhancements to the `advanced_scraper_validator.py` and `basic_scraper_validator.py` files, focusing on the management and utilization of organic query history. The changes include the addition of new imports, the initialization of organic history, and the implementation of logic to manage and use this history effectively.

Key changes include:

### Enhancements to `advanced_scraper_validator.py`:

* Added new imports to support the changes (`Any`, `Dict`, and `defaultdict`). [[1]](diffhunk://#diff-a574afe29428c9253a6e367b78a3a230d29ae91f102199bcfbdb9cd71e553b69L5-R5) [[2]](diffhunk://#diff-a574afe29428c9253a6e367b78a3a230d29ae91f102199bcfbdb9cd71e553b69L35-R35)
* Introduced `organic_history` as a dictionary to store organic queries with their timestamps.
* Implemented logic to clean up old entries from `organic_history` and utilize it for generating prompts, ensuring that synthetic queries are used as a fallback. [[1]](diffhunk://#diff-a574afe29428c9253a6e367b78a3a230d29ae91f102199bcfbdb9cd71e553b69L456-R486) [[2]](diffhunk://#diff-a574afe29428c9253a6e367b78a3a230d29ae91f102199bcfbdb9cd71e553b69L480-R511)
* Merged organic and synthetic responses and updated the history to mark used organic responses.
* Saved organic queries to `organic_history` during the response processing phase.

### Enhancements to `basic_scraper_validator.py`:

* Added new imports to support the changes (`Any`, `Dict`, and `defaultdict`).
* Introduced `organic_history` as a dictionary to store organic queries with their timestamps.
* Implemented logic to clean up old entries from `organic_history` and utilize it for generating prompts, ensuring that synthetic queries are used as a fallback. [[1]](diffhunk://#diff-9c824f81dc95f094e9b3e50455469b83df7074b402fef3f9db6c550b458897e6R402-R413) [[2]](diffhunk://#diff-9c824f81dc95f094e9b3e50455469b83df7074b402fef3f9db6c550b458897e6R424)
* Merged organic and synthetic responses and updated the history to mark used organic responses.
* Saved organic queries to `organic_history` during the response processing phase.